### PR TITLE
Compatibility with WGPS data

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ If you use the W-phase package for your own research, please cite the following 
 * python2.7 (or later)
 * You have to install numpy, matplotlib, basemap and netCDF4 to run some python scripts which make figures.
 * rdseed
+* sac
 
 To install these dependencies on MacOs, [you can refer to this page](http://wphase.unistra.fr/wiki/doku.php/wphase:macos).
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ To install the code, we must first setup a few environment variables. If you use
 setenv RDSEED       /path/to/rdseed/executable
 setenv GF_PATH      /path/to/greens/functions/database
 setenv WPHASE_HOME  /path/to/wphase/package
+setenv SAC          /path/to/sac/executable
+setenv SACHOME      /path/to/sac/aux/directory
 ```
 
 If you use bash:
@@ -47,9 +49,11 @@ If you use bash:
 export RDSEED=/path/to/rdseed/executable
 export GF_PATH=/path/to/greens/functions/database
 export WPHASE_HOME=/path/to/wphase/package
+export SAC=/path/to/sac/executable
+export SACHOME=/path/to/sac/aux/directory
 ```
 
-These variables are necessary both at installation time and at run time. In addition to these variables, it is handy to include the wphase bin directory into the PATH environment variable:
+These variables are necessary both at installation time and at run time. SAC and SACAUX are only necessary in order to use WGPS data. In addition to these variables, it is handy to include the wphase bin directory into the PATH environment variable:
 
 ```
 setenv PATH         ${PATH}:$WPHASE_HOME/bin

--- a/bin/RUNA3_gps.csh
+++ b/bin/RUNA3_gps.csh
@@ -1,0 +1,76 @@
+#!/bin/csh -f
+#
+# W phase package - RUNA3 (median and rms screening)
+# Starting from WGPS SAC files in DATA_org
+#
+# Zacharie Duputel, Luis Rivera and Hiroo Kanamori
+#
+
+source $WPHASE_HOME/bin/WP_HEADER_GPS.CSH
+
+##################################
+
+if ( ! -e i_master ) then
+   ${ECHO} "Error: file  i_master not available"
+   exit 1
+endif
+
+set my_argv = ($ARGV)
+set BIN     = $WPHASE_HOME/bin
+set EXTRACT = ${BIN}/extract.csh
+set PREPARE = ${BIN}/prepare_wp_gps.csh
+set WPINVER = ${BIN}/wpinversion
+
+set median  = "-med"
+set p2p_scr = `$GREP ^P2P_SCREENING i_master| $CUT -d':' -f2`
+if ( $#p2p_scr != 0 && $p2p_scr != "YES" ) set median = ""
+set ths     = "5.0 3.0 0.9"
+set rms_scr = `$GREP ^RMS_SCREENING i_master| $CUT -d':' -f2`
+if ( $#rms_scr != 0 ) set ths = "$rms_scr"
+ 
+
+if ( -e SYNTH ) ${RM} -rf SYNTH 
+${MKDIR} SYNTH; 
+#$EXTRACT
+#if $status exit 1
+$PREPARE
+if $status exit 1
+
+set version = "Version: "
+if ( -e $WPHASE_HOME/.svn/entries ) set version = "${version}`$HEAD -4 $WPHASE_HOME/.svn/entries | $TAIL -1`"
+set screening = "Screening: $median"
+set comgfdir  = "GF_PATH: $GF_PATH"
+
+$ECHO "COMMAND LINE: $WPINVER -log LOG/wpinversion.noth.log -osyndir SYNTH -pdata fort.15.noth $median \
+	${my_argv} -comment '$version' -comment '$screening' -comment '$comgfdir'"
+$WPINVER -log LOG/wpinversion.noth.log -osyndir SYNTH -pdata fort.15.noth $median \
+	${my_argv} -comment "$version" -comment "$screening" -comment "$comgfdir"
+
+${CP} p_wpinversion.ps p_wpinversion.noth.ps
+${CP} o_wpinversion o_wpinversion.noth
+${CP} WCMTSOLUTION WCMTSOLUTION.noth
+
+${CP} o_wpinversion o_wpinv
+
+
+foreach th ($ths)
+	set screening = "$screening  $th"
+    $ECHO -e "\nCOMMAND LINE: $WPINVER -th ${th} -ifil o_wpinversion -ofil o_wpinv.th_${th} \
+	-log LOG/wpinversion.th_${th}.log -ps p_wpinversion.th_${th} \
+	-osyndir SYNTH -ocmtf  WCMTSOLUTION.th_${th} -old ${my_argv} \
+	-comment '$version' -comment '$screening' -comment '$comgfdir'" 
+    $WPINVER -th ${th} -ifil o_wpinversion -ofil o_wpinv.th_${th} \
+    -log LOG/wpinversion.th_${th}.log -ps p_wpinversion.th_${th}.ps \
+    -osyndir SYNTH -ocmtf  WCMTSOLUTION.th_${th} -old ${my_argv} \
+	-comment "$version" -comment "$screening" -comment "$comgfdir" 
+    if $status exit 1
+    ${CP} -f o_wpinv.th_$th o_wpinversion
+end
+
+${CP} WCMTSOLUTION.th_${th} WCMTSOLUTION
+${CP} p_wpinversion.th_${th}.ps p_wpinversion.ps
+${CP} LOG/wpinversion.th_${th}.log LOG/wpinversion.log
+#${RM} -rf GF
+
+${ECHO} -e "\nOutput files: o_wpinversion WCMTSOLUTION p_wpinversion.ps"
+${ECHO} "              fort.15 fort.15_LHZ fort.15_LHN fort.15_LHE"

--- a/bin/prepare_wp_gps.csh
+++ b/bin/prepare_wp_gps.csh
@@ -1,0 +1,89 @@
+#!/bin/csh -f
+# Command lines examples:
+# prepare_wp.csh 
+# prepare_wp.csh Z
+# prepare_wp.csh -a
+#
+
+source $WPHASE_HOME/bin/WP_HEADER_GPS.CSH
+set LOG        = LOG
+set DATA       = DATA
+set DATA_org   = DATA_org
+set BEFORE     = 300          # number of points before origin
+set AFTER      = 1200         # number of points after origin
+set FILT_ORDER = `$GREP filt_order i_master | $CUT -d ':' -f2 | $AWK '{print $1}'`
+set FILT_CF1   = `$GREP filt_cf1 i_master | $CUT -d ':' -f2 | $AWK '{print $1}'`
+set FILT_CF2   = `$GREP filt_cf2 i_master | $CUT -d ':' -f2 | $AWK '{print $1}'`
+set FILT_PASS  = `$GREP filt_pass i_master | $CUT -d ':' -f2 | $AWK '{print $1}'`
+set CMPS       = "Z N E 1 2"
+
+# command line arguments 
+set trim_flag = '-u'
+set my_argv = ($ARGV)
+if ($#my_argv > 0) then
+    set CMPS = $my_argv
+    if ( $CMPS == '-a' ) then
+	set CMPS = "Z N E 1 2"
+	set trim_flag = "-a"
+    endif
+endif
+
+
+if ( ! -e ${DATA_org} ) then
+   ${ECHO} "Missing ${DATA_org}"
+   exit 1
+endif
+ 
+if ( -e ${DATA} ) $RM -rf ${DATA}
+${MKDIR} ${DATA}
+${MKDIR} -p ${LOG}
+
+###############################################
+# Renaming files, cutting and filtering (sac) #
+${ECHO} "Renaming files, cutting and filtering (sac)..."
+cd ${DATA_org}
+foreach file (*.sac)
+    ${SAC} << EOF>/dev/null
+    r $file
+    SETBB TEMP0 $file
+    SETBB TEMP1 &$file,NZYEAR
+    SETBB TEMP2 %TEMP1%.
+    SETBB TEMP3 %TEMP2%&$file,NZJDAY
+    SETBB TEMP4 %TEMP3%.
+    SETBB TEMP5 %TEMP4%&$file,NZHOUR
+    SETBB TEMP6 %TEMP5%.
+    SETBB TEMP7 %TEMP6%&$file,NZMIN
+    SETBB TEMP8 %TEMP7%.
+    SETBB TEMP9 %TEMP8%&$file,NZSEC
+    SETBB TEMP10 %TEMP9%.0000.
+    SETBB TEMP11 %TEMP10%&$file,KNETWK
+    SETBB TEMP12 %TEMP11%.
+    SETBB TEMP13 %TEMP12%&$file,KSTNM
+    SETBB TEMP14 %TEMP13%..
+    SETBB TEMP15 %TEMP14%&$file,KCMPNM
+    SETBB TEMP16 %TEMP15%.
+    SETBB TEMP17 %TEMP16%X.1sps.SAC
+    cut o -${BEFORE} ${AFTER}
+    r $file
+    bp c ${FILT_CF1} ${FILT_CF2} n ${FILT_ORDER} p ${FILT_PASS}
+    w %TEMP17
+    q
+EOF
+end
+cd ..
+${MV} ${DATA_org}/*.SAC ${DATA}
+
+###############################################
+# Trimming files                              #
+${LS} ${DATA}/*.SAC >! ${DATA}/_sac_files_list
+$TRIM_SAC_FILES i_master ${DATA}/_sac_files_list scr_dat_fil_list $trim_flag # Use of "-u" will allow only one network per-channel
+
+################################################
+# Synthetics preparatioN:convolution and filter #
+${ECHO} "Synthetics convolution and filter...  "
+${PREP_KERNELS} scr_dat_fil_list l
+if $status exit(1)
+
+################################################
+# Creating input file for inversion ...        #
+${CUT} -d' ' -f1  scr_dat_fil_list >! i_wpinversion

--- a/src/configure.csh
+++ b/src/configure.csh
@@ -141,3 +141,86 @@ foreach com ($coms)
          echo "set $COM = $compath" >> ${o_file}
     endif
 end
+
+unset o_file
+set o_file = $BIN/WP_HEADER_GPS.CSH
+
+echo "Creating  $BIN/WP_HEADER_GPS.CSH"
+
+rm -f ${o_file}
+
+cat << EOF > ${o_file}
+set      gf_path = \$GF_PATH
+set      wp_home = \$WPHASE_HOME
+set      rdseed  = \$RDSEED
+set      home    = \$HOME
+set      sac     = \$SAC
+set      sacaux  = \$SACAUX
+
+unsetenv *
+
+setenv   HOME      \$home
+setenv   ARGV      "\$argv"
+setenv   DISPLAY   :0.0
+setenv   GF_PATH   \$gf_path
+setenv   WPHASE_HOME   \$wp_home
+setenv   RDSEED    \$rdseed
+setenv   SAC       \$sac
+setenv   SACAUX    \$sacaux
+
+unset    *
+
+setenv   LC_ALL en_US
+
+set BIN                  = \$WPHASE_HOME/bin
+set TRIM_SAC_FILES	 = \$BIN/trim_sac_files
+set TRIM_SAC_FILES_QRT	 = \$BIN/trim_sac_files_qrt
+set MAKE_RESP_TABLE      = \$BIN/make_resp_lookup_table
+
+set REC_DEC_FILT         = \$BIN/rec_dec_filt
+set SYN_CONV_FILT        = \$BIN/syn_conv_filt
+set ROT_HORIZ_CMP        = \$BIN/rot_horiz_cmp
+
+set PREP_KERNELS         = \${BIN}/prep_kernels
+set PREP_KERNELS_only_Z  = \${BIN}/prep_kernels_only_Z
+
+set FAST_SYNTH_Z         = \$BIN/fast_synth_only_Z
+set FAST_SYNTH           = \$BIN/fast_synth
+set FAST_SYNTH_ROT       = \$BIN/fast_synth_rot
+
+set DELTA_T              = \$BIN/delta_t
+set READCMT              = \$BIN/readcmt
+set SYNTHS               = \$BIN/synth_v6
+set CONV_VBB             = \$BIN/conv_vbb
+
+set SACLST               = \$BIN/saclst
+set DECIMATE             = \$BIN/decim_one_sac_file_to_1sps
+set DECIMATE_2SPS        = \$BIN/decim_one_sac_file_to_2sps
+
+# commands
+EOF
+
+set coms = "echo ls ln cp mv rm sed cat pwd grep expand date mkdir cut awk find head tail sort touch od tr wc seq xargs paste dirname basename ps2pdf gs"
+
+set dirs = '/usr/bin /bin'
+unset WHICH
+foreach dir ($dirs)
+	if -e $dir/which set WHICH = $dir/which
+end
+if ! $?WHICH then
+	echo "ERROR: Command 'which' not found in $dirs"
+        exit 1
+endif
+
+
+foreach com ($coms)
+    unset compath
+    set COM        = `echo $com | tr "[:lower:]" "[:upper:]"` 
+    set compath    = `$WHICH $com`
+    if ( $status ) then
+         echo "ERROR: Command $com not found in "'$PATH'
+         exit;
+    else
+         echo "set $COM = $compath" >> ${o_file}
+    endif
+end


### PR DESCRIPTION
Included RUNA3_gps.csh.

This routine starts directly from displacement WGPS data.
Auxiliary subroutines: prepare_wp_gps.csh, WP_HEADER_GPS.CSH
Also modified the README to include a dependency (only for this new routine) on SAC (cutting files and filtering), and configure.csh to create WP_HEADER_GPS.CSH along with the original header.

If accepted, the wiki should be modified to include this new RUNA script.
Happy to contribute!