### PR TITLE
differential screening for horizontal and vertical components

### DIFF
--- a/src/gcmtascii.c
+++ b/src/gcmtascii.c
@@ -179,7 +179,7 @@ int main(int argc, char *argv[])
   // Moment tensor values are divide by POW (defined at 1E+28) when read from cmtfile
   get_planes(eq.vm[1], &eval3, &evec3, &s1,&d1,&r1, &s2,&d2,&r2) ;
   M0     = ((fabs(eval3[0]) + fabs(eval3[2])) * (double)POW) / 2. ; 
-  Mw     = (log10(M0) - 16.1) / 1.5 ;  
+  Mw     = (log10(M0) - 16.1) / 1.5 + 0.005 ;  
   
   /* Principal axes              */
   for (i=0; i<3 ; i++)

--- a/src/wpinversion.c
+++ b/src/wpinversion.c
@@ -197,6 +197,8 @@ int main(int argc, char *argv[])
     free((void*)opt.rms_r);
     free((void*)opt.p2p);
     free((void*)opt.avg);
+    free((void*)opt.p2ph);
+    free((void*)opt.avgh);
     free((void*)opt.wgt);	 
     free((void*)hd_synt);
     return 0;

--- a/src/wpinversion.h
+++ b/src/wpinversion.h
@@ -79,8 +79,10 @@ typedef struct
   int    hdsafe, hdind, dc_flag, ref_flag,ip,ib[4] ;
   double th_val, cth_val, df_val, med_val,ts;
   double op_pa, p2p_med, p2p_low, p2p_high  ;
+  double p2ph_med,p2ph_low, p2ph_high       ;
   double dts_min,dts_step,dts_max, dts_val  ;
-  double *rms_in,rms_r_th,*rms_r,*p2p,*avg  ; 
+  double *rms_in,rms_r_th,*rms_r,*p2p,*avg  ;
+  double *p2ph,*avgh ;
   double xy_dx, dlat, dlon, dz, mindep, azp ;
   double ntr_val, wZ, wN, wE, priorsdrM0[4] ;
   double med_minfc, med_maxfc               ;

--- a/src/wpinversion_sub.c
+++ b/src/wpinversion_sub.c
@@ -957,7 +957,7 @@ void inversion(int M, int nsac, sachdr *hd_synt, double ***G, double **d,
         for(i=0;i<M;i++)
         {
             for(k=0;k<M;k++)
-                fprintf( o_cov,"%16.2e ", cov[i][k]) ;
+                fprintf( o_cov,"%16.4e ", cov[i][k]) ;
             fprintf( o_cov,"\n") ;
         }
         fclose(o_cov) ;
@@ -1629,15 +1629,15 @@ void set_matrices (int *nsac, int *nsini,char ***sacfiles,sachdr **hd_synt,doubl
             opt->p2p[ns] *= 1000                 ;
             opt->avg[ns] *= 1000                 ; 
             if ( hd_data.kcmpnm[2]  == 'N' ||  hd_data.kcmpnm[2] == 'E' ||  hd_data.kcmpnm[2] == '1' || hd_data.kcmpnm[2] == '2' )
-	    {
+            {
                 opt->p2ph[ns] = opt->p2p[ns];
                 opt->avgh[ns] = opt->avg[ns];
-	    }
+            }
 	    else
-	    {
+            {
                 opt->p2ph[ns] = -999.;
                 opt->avgh[ns] = -999.;
-	    }
+            }
         }
 
         strcpy( (*sacfiles)[ns], datafile) ;
@@ -1759,7 +1759,7 @@ void screen_med(int *nsac, char **data_name, double **data, double ***G,
         {
 	    val = opt->p2ph[j];
 	    if ( (minh < val) && (val < maxh) && (fabs(opt->avgh[j]) < (opt->p2ph_med)/2.) )
-	    {
+            {
 		data_name[newn] = data_name[j] ;
 		data[newn]      = data[j]      ;
 		G[newn]         = G[j]         ;
@@ -1771,9 +1771,9 @@ void screen_med(int *nsac, char **data_name, double **data, double ***G,
 		opt->wgt[newn]  = opt->wgt[j]  ;
 		opt->rms_r[newn]=opt->rms_r[j] ;
 		newn++ ;
-	    }
+            }
 	    else
-	    {
+            {
 		fprintf(stderr,"**** Rejected trace (p2p or avg out of bounds): %s\n", data_name[j]) ;
 		if (o_log != NULL)
 		  fprintf(o_log,"**** Rejected trace (p2p or avg out of bounds): %s\n",data_name[j]) ;
@@ -1781,10 +1781,10 @@ void screen_med(int *nsac, char **data_name, double **data, double ***G,
 		free((void*)data[j])     ;
 		free_G(G+j)              ;
             }
-	}
+        }
 	/* Screen vertical streams */
 	else
-	{
+        {
 	    val = opt->p2p[j];
 	    if ( (min < val) && (val < max) && (fabs(opt->avg[j]) < (opt->p2p_med)/2.) )
             {
@@ -2752,7 +2752,7 @@ void xy_gridsearch(int nsac,int M, int nd,double *dv,double *tv, sachdr *hd_synt
         #ifdef _OPENMP
         #pragma omp parallel default(shared) private(j)
         {
-	 #pragma omp for schedule(dynamic)
+        #pragma omp for schedule(dynamic)
             for(j=0;j<Ngrid;j++)
                 run_xy_gs(new_loc+j,1,nsac,M,nd,dv,tv,hd_synt,data,eq,opt,vrms+j,vms+j,1) ;
         }


### PR DESCRIPTION
Hi,

A pull-request for a modification of the initial screening (p2p and med).
The initial screening will be done separately  over all horizontals (E,N) and verticals components to avoid in some case a lot of rejected station especially for strong strike-slip event.

Anthony